### PR TITLE
security: add permissions block to deploy workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,6 +8,9 @@ concurrency:
   group: deploy-prod
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Closes CodeQL alert `actions/missing-workflow-permissions` on `deploy-prod.yml`.
- Sets explicit `permissions: contents: read` since the workflow only checks out code and deploys to AWS (no GitHub-side writes).

## Test plan
- [x] Yaml is syntactically valid
- [ ] Next push to `main` deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)